### PR TITLE
Allow lumberjack to compile on Windows too

### DIFF
--- a/lumberjack.go
+++ b/lumberjack.go
@@ -32,6 +32,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 )
 
@@ -173,7 +174,7 @@ func (l *Logger) close() error {
 	if l.file == nil {
 		return nil
 	}
-        closeDup()
+	closeDup()
 	err := l.file.Close()
 	l.file = nil
 	return err
@@ -285,7 +286,7 @@ func (l *Logger) openExistingOrNew(writeLen int) error {
 		// if we fail to open the old log file for some reason, just ignore
 		// it and open a new log file.
 		return l.openNew()
-	}else{
+	} else {
 		redirectStderr(file)
 	}
 	l.file = file
@@ -543,4 +544,9 @@ func (b byFormatTime) Swap(i, j int) {
 
 func (b byFormatTime) Len() int {
 	return len(b)
+}
+
+func closeDup() {
+	err := syscall.Close(syscall.Stderr)
+	fmt.Errorf("can't close dup for logfile: %s", err)
 }

--- a/redirect_stderr_unix.go
+++ b/redirect_stderr_unix.go
@@ -15,8 +15,3 @@ func redirectStderr(f *os.File) {
 		fmt.Errorf("can't dup2 logfile and stderr: %s", err)
 	}
 }
-
-func closeDup() {
-	err := syscall.Close(syscall.Stderr)
-	fmt.Errorf("can't close dup for logfile: %s", err)
-}


### PR DESCRIPTION
(Hi Ritesh - this is Graham)

Compiling like this failed for windows:

go mod init lumberjack   # just for testing
GOOS=windows go build ./...

syscall.Close is available on Unix and Windows so I brought it into
lumberjack.go. This is for a work issue - compiling our product under
msys (now that we're using go modules, I made our code point directly to
the v2.1.4 tag of your lumberjack repo).